### PR TITLE
Update github output syntax

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -65,9 +65,9 @@ runs:
             )
         for host_address in itertools.islice(network, 1, None):
             if host_address != address:
-                with open(os.environ['GITHUB_OUTPUT'], "a") as f:
-                    print(f"devstack-ip={address}", file=f)
-                    print(f"host-address={host_address}/{prefix_len}", file=f)
+                with open(os.environ['GITHUB_OUTPUT'], "a") as file:
+                    print(f"devstack-ip={address}", file=file)
+                    print(f"host-address={host_address}/{prefix_len}", file=file)
                 break
 
     - name: Setup LXD

--- a/action.yaml
+++ b/action.yaml
@@ -53,6 +53,7 @@ runs:
       run: |
         import ipaddress
         import itertools
+        import os
 
         interface = ipaddress.IPv4Interface("${{ inputs.network }}")
         address = interface.ip
@@ -64,8 +65,9 @@ runs:
             )
         for host_address in itertools.islice(network, 1, None):
             if host_address != address:
-                print("::set-output name=devstack-ip::{}".format(address))
-                print("::set-output name=host-address::{}/{}".format(host_address, prefix_len))
+                with open(os.environ['GITHUB_OUTPUT'], "a") as f:
+                    print(f"devstack-ip={address}", file=f)
+                    print(f"host-address={host_address}/{prefix_len}", file=f)
                 break
 
     - name: Setup LXD
@@ -237,5 +239,5 @@ runs:
         CREDENTIALS="${CREDENTIALS//'%'/'%25'}"
         CREDENTIALS="${CREDENTIALS//$'\n'/'%0A'}"
         CREDENTIALS="${CREDENTIALS//$'\r'/'%0D'}"
-        echo "::set-output name=credentials::$CREDENTIALS"
+        echo "credentials=$CREDENTIALS" >> $GITHUB_OUTPUT
         rm credentials

--- a/action.yaml
+++ b/action.yaml
@@ -236,8 +236,5 @@ runs:
       shell: bash
       run: |
         CREDENTIALS="$(cat credentials)"
-        CREDENTIALS="${CREDENTIALS//'%'/'%25'}"
-        CREDENTIALS="${CREDENTIALS//$'\n'/'%0A'}"
-        CREDENTIALS="${CREDENTIALS//$'\r'/'%0D'}"
         echo "credentials=$CREDENTIALS" >> $GITHUB_OUTPUT
         rm credentials

--- a/action.yaml
+++ b/action.yaml
@@ -118,7 +118,6 @@ runs:
       if: inputs.use-cache == 'true' && steps.devstack-swift-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        mkdir .devstack
         cd .devstack
         lxc stop devstack --project devstack
         lxc snapshot devstack devstack-snapshot --project devstack

--- a/action.yaml
+++ b/action.yaml
@@ -236,6 +236,6 @@ runs:
       shell: bash
       run: |
         echo "credentials<<EOF" >> $GITHUB_OUTPUT
-        cat credentials >> $GITHUB_OUTPUT
+        sed -e '$a\' credentials >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
         rm credentials

--- a/action.yaml
+++ b/action.yaml
@@ -118,6 +118,7 @@ runs:
       if: inputs.use-cache == 'true' && steps.devstack-swift-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
+        mkdir .devstack
         cd .devstack
         lxc stop devstack --project devstack
         lxc snapshot devstack devstack-snapshot --project devstack

--- a/action.yaml
+++ b/action.yaml
@@ -235,6 +235,7 @@ runs:
       id: output-credentials
       shell: bash
       run: |
-        CREDENTIALS="$(cat credentials)"
-        echo "credentials=$CREDENTIALS" >> $GITHUB_OUTPUT
+        echo "credentials<<EOF" >> $GITHUB_OUTPUT
+        cat credentials >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
         rm credentials


### PR DESCRIPTION
This PR aims to update the deprecated `::set-output name=` syntax to the newer $GITHUB_OUTPUT syntax.